### PR TITLE
Fix mood input state refresh

### DIFF
--- a/src/components/Lv1/MoodCalendar.vue
+++ b/src/components/Lv1/MoodCalendar.vue
@@ -65,7 +65,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { supabase } from '@/lib/supabase'
 
 // リアクティブデータ
@@ -182,7 +182,7 @@ const closeModal = () => {
   selectedDayData.value = null
 }
 
-onMounted(async () => {
+const fetchMoodRecords = async () => {
   currentDate.value = new Date()
 
   const { data: { user }, error: userError } = await supabase.auth.getUser()
@@ -208,6 +208,17 @@ onMounted(async () => {
     date: entry.created_at.split('T')[0],
     moodLevel: entry.mood_level
   }))
+  
+  // 既に表示中なら再描画は自動で行われる
+}
+
+onMounted(async () => {
+  await fetchMoodRecords()
+  document.addEventListener('mood-recorded', fetchMoodRecords)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('mood-recorded', fetchMoodRecords)
 })
 </script>
 

--- a/src/components/Lv1/MoodChart.vue
+++ b/src/components/Lv1/MoodChart.vue
@@ -97,7 +97,7 @@ const getGentleMessage = () => {
 const moodRecords = ref([])
 const moodRecordsRaw = ref([])
 
-onMounted(async () => {
+const fetchMoodRecords = async () => {
   const { data: { user }, error: userError } = await supabase.auth.getUser()
   if (userError || !user) {
     console.error('ユーザー情報取得失敗:', userError)
@@ -125,7 +125,16 @@ onMounted(async () => {
     moodLevel: entry.mood_level
   }))
 
-  initChart()
+  if (chartInstance) {
+    updateChart()
+  } else {
+    initChart()
+  }
+}
+
+onMounted(async () => {
+  await fetchMoodRecords()
+  document.addEventListener('mood-recorded', fetchMoodRecords)
 })
 
 // コンポーネントがアンマウントされる時にチャートを破棄
@@ -133,6 +142,7 @@ onUnmounted(() => {
   if (chartInstance) {
     chartInstance.destroy()
   }
+  document.removeEventListener('mood-recorded', fetchMoodRecords)
 })
 
 // 期間変更

--- a/src/components/Lv1/MoodInput.vue
+++ b/src/components/Lv1/MoodInput.vue
@@ -108,7 +108,8 @@ async function checkMoodRecorded() {
     if (!user) {
       // ローカルストレージでフォールバック
       const storedDate = localStorage.getItem('mood-recorded-date')
-      if (storedDate === getTodayDateStr()) {
+      const submitted = localStorage.getItem('mood-submitted') === 'true'
+      if (storedDate === getTodayDateStr() || submitted) {
         isCompleted.value = true
         // 完了時の表示情報を復元
         const localMood = JSON.parse(localStorage.getItem('last-mood'))
@@ -198,6 +199,7 @@ async function confirmMood() {
     // ログイン状態に関わらずローカルストレージにも記録（フォールバック用）
     localStorage.setItem('mood-recorded-date', getTodayDateStr())
     localStorage.setItem('last-mood', JSON.stringify({ label: moodData.label, value: moodData.value, color: moodData.color }))
+    localStorage.setItem('mood-submitted', 'true')
 
 
     // 完了状態を設定
@@ -211,6 +213,7 @@ async function confirmMood() {
 
     showConfirm.value = false
     isCompleted.value = true
+    document.dispatchEvent(new Event('mood-recorded'))
 
   } catch (error) {
     console.error('予期しないエラー:', error)
@@ -223,6 +226,7 @@ async function confirmMood() {
 function resetMood() {
   localStorage.removeItem('mood-recorded-date')
   localStorage.removeItem('last-mood')
+  localStorage.removeItem('mood-submitted')
   isCompleted.value = false
   completedMood.value = null
   goBack()

--- a/src/components/Lv2/MoodCalendar.vue
+++ b/src/components/Lv2/MoodCalendar.vue
@@ -82,7 +82,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { supabase } from '@/lib/supabase'
 
 // リアクティブデータ
@@ -287,6 +287,11 @@ watch(currentDate, fetchMoodRecords, { immediate: true })
 
 onMounted(() => {
   // watchの immediate: true で初期ロードが実行されるため、ここは空でOK
+  document.addEventListener('mood-recorded', fetchMoodRecords)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('mood-recorded', fetchMoodRecords)
 })
 </script>
 

--- a/src/components/Lv2/MoodChart.vue
+++ b/src/components/Lv2/MoodChart.vue
@@ -113,7 +113,7 @@ const getGentleMessage = () => {
 const moodRecords = ref([])
 const moodRecordsRaw = ref([])
 
-onMounted(async () => {
+const fetchMoodRecords = async () => {
   const { data: { user }, error: userError } = await supabase.auth.getUser()
   if (userError || !user) {
     console.error('ユーザー情報取得失敗:', userError)
@@ -147,13 +147,23 @@ onMounted(async () => {
     // actionMemo: entry.action_memo
   }))
 
-  initChart()
+  if (chartInstance) {
+    updateChart()
+  } else {
+    initChart()
+  }
+}
+
+onMounted(async () => {
+  await fetchMoodRecords()
+  document.addEventListener('mood-recorded', fetchMoodRecords)
 })
 
 onUnmounted(() => {
   if (chartInstance) {
     chartInstance.destroy()
   }
+  document.removeEventListener('mood-recorded', fetchMoodRecords)
 })
 
 const changePeriod = (days) => {

--- a/src/components/Lv3/MoodChart.vue
+++ b/src/components/Lv3/MoodChart.vue
@@ -97,7 +97,7 @@ const getGentleMessage = () => {
 const moodRecords = ref([])
 const moodRecordsRaw = ref([])
 
-onMounted(async () => {
+const fetchMoodRecords = async () => {
   const { data: { user }, error: userError } = await supabase.auth.getUser()
   if (userError || !user) {
     console.error('ユーザー情報取得失敗:', userError)
@@ -125,7 +125,16 @@ onMounted(async () => {
     moodLevel: entry.mood_level
   }))
 
-  initChart()
+  if (chartInstance) {
+    updateChart()
+  } else {
+    initChart()
+  }
+}
+
+onMounted(async () => {
+  await fetchMoodRecords()
+  document.addEventListener('mood-recorded', fetchMoodRecords)
 })
 
 // コンポーネントがアンマウントされる時にチャートを破棄
@@ -133,6 +142,7 @@ onUnmounted(() => {
   if (chartInstance) {
     chartInstance.destroy()
   }
+  document.removeEventListener('mood-recorded', fetchMoodRecords)
 })
 
 // 期間変更

--- a/src/components/Lv3/MoodInput3.vue
+++ b/src/components/Lv3/MoodInput3.vue
@@ -91,7 +91,8 @@ function getTodayDateStr() {
 
 function checkMoodRecorded() {
   const storedDate = localStorage.getItem('mood-recorded-date')
-  moodRecordedToday.value = storedDate === getTodayDateStr()
+  const submitted = localStorage.getItem('mood-submitted') === 'true'
+  moodRecordedToday.value = storedDate === getTodayDateStr() || submitted
 }
 
 function selectMood(option) {
@@ -112,6 +113,7 @@ function goBack() {
 
 function confirmMood() {
   localStorage.setItem('mood-recorded-date', getTodayDateStr())
+  localStorage.setItem('mood-submitted', 'true')
   moodRecordedToday.value = true
 
   emit('mood-selected', {
@@ -123,11 +125,13 @@ function confirmMood() {
   })
 
   goBack()
+  document.dispatchEvent(new Event('mood-recorded'))
 }
 
 // // 開発者ボタン
 function resetMood() {
   localStorage.removeItem('mood-recorded-date')
+  localStorage.removeItem('mood-submitted')
   moodRecordedToday.value = false
 }
 


### PR DESCRIPTION
## Purpose
- ensure chart and calendar update right after mood submission
- keep recorded state after reloading the page

## Summary
- add localStorage flags and dispatch `mood-recorded` events from mood inputs
- listen for the event in charts and calendars to re-fetch data
- check stored flags on mount to keep completed status

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853b11f5348832da668dcfdeca4bfc3