### PR TITLE
fix mood insert id

### DIFF
--- a/src/components/Lv1/MoodInput.vue
+++ b/src/components/Lv1/MoodInput.vue
@@ -182,12 +182,14 @@ async function confirmMood() {
       // Supabaseにinsert（ログインしている場合のみ）
       const { error } = await supabase
         .from('moods')
-        .insert([{
-          // id: crypto.randomUUID(), // DB側で自動生成されるなら不要
-          user_id: user.id,
-          mood: moodData.label,
-          mood_level: moodMap[moodData.label]
-        }])
+        .insert([
+          {
+            id: crypto.randomUUID(),
+            user_id: user.id,
+            mood: moodData.label,
+            mood_level: moodMap[moodData.label],
+          },
+        ])
 
       if (error) {
         throw new Error(`Supabaseへの保存に失敗: ${error.message}`)


### PR DESCRIPTION
## 変更目的
Lv1 の `MoodInput.vue` で気分の保存時に `id` が指定されず Supabase 側でエラーが発生していたため、UUID を付与して保存できるよう修正しました。

## 主な変更点
- `insert` 時に `id: crypto.randomUUID()` を追加

## テスト結果
- `npm run build` が成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_6858f209dd58832db6419ffb939e9601