### PR TITLE
Improve signup validation in LoginForm

### DIFF
--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -106,6 +106,11 @@ const handleSignup = async () => {
     return
   }
 
+  if (password.value.length < 6) {
+    errorMessage.value = 'パスワードは6文字以上で入力してください'
+    return
+  }
+
   isLoading.value = true
   errorMessage.value = ''
 
@@ -117,7 +122,7 @@ const handleSignup = async () => {
 
     if (error) {
       console.error('登録エラー:', error)
-      errorMessage.value = '登録に失敗しました。'
+      errorMessage.value = error.message || '登録に失敗しました。'
     } else {
       console.log('登録成功:', data)
       emit('login', {


### PR DESCRIPTION
## 目的
サインアップ時に6文字未満のパスワードを入力すると422エラーが発生していたため、事前に検証を追加してわかりやすいメッセージを表示するようにしました。

## 変更内容
- `LoginForm.vue` にパスワードの長さチェックを追加
- Supabase からのエラーメッセージをそのまま表示するよう修正

## テスト結果
- `npm run build` を実行しビルド成功を確認
- `npm run lint` は定義されておらずエラー出力


------
https://chatgpt.com/codex/tasks/task_e_6858fb137010832d9064af2edc48b45b