### PR TITLE
fix: unify REST headers

### DIFF
--- a/src/components/Lv1/MoodTrend.vue
+++ b/src/components/Lv1/MoodTrend.vue
@@ -11,7 +11,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
-import { supabase } from '@/lib/supabase'
+import { supabase, buildRestHeaders } from '@/lib/supabase'
 
 const moods = ref([])
 
@@ -68,11 +68,7 @@ onMounted(async () => {
   })
 
   const url = `${import.meta.env.VITE_SUPABASE_URL}/rest/v1/moods?${params.toString()}`
-  const headers = {
-    apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
-    Authorization: `Bearer ${accessToken}`,
-    Accept: 'application/json',
-  }
+  const headers = buildRestHeaders(accessToken)
 
   console.log('🟡 リクエストURL:', url)
   console.log('🟡 リクエストヘッダー:', headers)

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -10,3 +10,10 @@ if (!supabaseUrl || !supabaseAnonKey) {
 }
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+
+// REST API呼び出し時に使用する共通ヘッダーを生成
+export const buildRestHeaders = (accessToken) => ({
+  apikey: supabaseAnonKey,
+  Authorization: `Bearer ${accessToken}`,
+  Accept: 'application/json',
+})


### PR DESCRIPTION
## 目的
Supabase REST API へ送るリクエストで `Accept` ヘッダーが不足するケースを防ぐため、共通関数を追加しました。

## 変更内容
- `src/lib/supabase.js` に `buildRestHeaders` を追加し、`apikey`・`Authorization`・`Accept` を一括設定
- `MoodTrend.vue` の REST API 呼び出しで上記関数を利用

## テスト結果
- `npm run build` が成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_685a4c3c0fd0832d87d0f8331206bf9a