### PR TITLE
Fix Supabase 406 error

### DIFF
--- a/src/components/Lv1/MoodTrend.vue
+++ b/src/components/Lv1/MoodTrend.vue
@@ -38,27 +38,24 @@ onMounted(async () => {
     }
     moods.value = data
 
-    // 3. REST APIで気分データを取得（例として mood と mood_level のみ）
+    // 3. mood と mood_level のみ取得する例 (REST fetch を supabase-js に変更)
     const user = session.user
-    const accessToken = session.access_token
     const createdAfter = new Date('2025-06-23T15:00:00.000Z')
 
-    const params = new URLSearchParams({
-      select: 'mood,mood_level',
-      user_id: `eq.${user.id}`,
-      created_at: `gte.${createdAfter.toISOString()}`,
-    })
+    const { data: moodData, error: moodError } = await supabase
+      .from('moods')
+      .select('mood, mood_level')
+      .eq('user_id', user.id)
+      .gte('created_at', createdAfter.toISOString())
 
-    const url = `${import.meta.env.VITE_SUPABASE_URL}/rest/v1/moods?${params.toString()}`
-    const headers = buildRestHeaders(accessToken)
-
-    const response = await fetch(url, { headers })
-    if (!response.ok) {
-      errorMessage.value = `エラー: ${response.status} ${response.statusText}`
+    if (moodError) {
+      errorMessage.value = 'moodデータの取得に失敗しました'
+      console.error(moodError)
       return
     }
 
-    await response.json()
+    // 必要であれば取得したデータを利用
+    console.log('Filtered moods:', moodData)
   } catch (err) {
     // まとめてエラー処理
     errorMessage.value = 'データ取得中にエラーが発生しました'


### PR DESCRIPTION
## 目的
Supabase REST 呼び出しで `406 Not Acceptable` が発生していたため、`supabase-js` のクエリに書き換えました。

## 変更内容
- `MoodTrend.vue` の REST API 呼び出し部分を `supabase-js` に置き換え、取得失敗時のエラーハンドリングを追加

## テスト結果
- `npm run build` が成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_685ceb198d98832db79ade472f3ca693