### PR TITLE
Fix missing </style> in KuesutMove

### DIFF
--- a/src/components/Lv3/KuesutMove.vue
+++ b/src/components/Lv3/KuesutMove.vue
@@ -460,3 +460,5 @@ textarea:focus {
 .fade-enter, .fade-leave-to /* .fade-leave-active in <2.1.8 */ {
   opacity: 0;
 }
+
+</style>


### PR DESCRIPTION
## 変更目的
Vue テンプレートの構文エラーを解消するため。

## 変更内容
- `KuesutMove.vue` の `<style>` セクションに閉じタグを追加

## テスト結果
- `npm run build` が成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_686cb1021014832d9d2f611a4fdde7f1